### PR TITLE
Reset

### DIFF
--- a/src/main/kotlin/no/nav/syfo/syfosmvarsel/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/syfosmvarsel/Bootstrap.kt
@@ -122,7 +122,6 @@ fun main() {
 
     RenewVaultService(vaultCredentialService, applicationState).startRenewTasks()
     launchListeners(
-        env = env,
         applicationState = applicationState,
         avvistKafkaConsumer = avvistKafkaConsumer,
         nyKafkaConsumer = nyKafkaConsumer,
@@ -146,7 +145,6 @@ fun createListener(applicationState: ApplicationState, applicationLogic: suspend
 
 @KtorExperimentalAPI
 fun launchListeners(
-    env: Environment,
     applicationState: ApplicationState,
     avvistKafkaConsumer: KafkaConsumer<String, String>,
     nyKafkaConsumer: KafkaConsumer<String, String>,
@@ -156,11 +154,11 @@ fun launchListeners(
     statusendringService: StatusendringService
 ) {
     createListener(applicationState) {
-        blockingApplicationLogicAvvistSykmelding(applicationState, avvistKafkaConsumer, avvistSykmeldingService, env)
+        blockingApplicationLogicAvvistSykmelding(applicationState, avvistKafkaConsumer, avvistSykmeldingService)
     }
 
     createListener(applicationState) {
-        blockingApplicationLogicNySykmelding(applicationState, nyKafkaConsumer, nySykmeldingService, env)
+        blockingApplicationLogicNySykmelding(applicationState, nyKafkaConsumer, nySykmeldingService)
     }
 
     createListener(applicationState) {
@@ -168,11 +166,11 @@ fun launchListeners(
     }
 }
 
+@KtorExperimentalAPI
 suspend fun blockingApplicationLogicAvvistSykmelding(
     applicationState: ApplicationState,
     kafkaConsumer: KafkaConsumer<String, String>,
-    avvistSykmeldingService: AvvistSykmeldingService,
-    env: Environment
+    avvistSykmeldingService: AvvistSykmeldingService
 ) {
     while (applicationState.ready) {
         kafkaConsumer.poll(Duration.ofMillis(0)).forEach {
@@ -192,11 +190,11 @@ suspend fun blockingApplicationLogicAvvistSykmelding(
     }
 }
 
+@KtorExperimentalAPI
 suspend fun blockingApplicationLogicNySykmelding(
     applicationState: ApplicationState,
     kafkaConsumer: KafkaConsumer<String, String>,
-    nySykmeldingService: NySykmeldingService,
-    env: Environment
+    nySykmeldingService: NySykmeldingService
 ) {
     while (applicationState.ready) {
         kafkaConsumer.poll(Duration.ofMillis(0)).forEach {

--- a/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.syfosmvarsel.brukernotifikasjon
 import no.nav.brukernotifikasjon.schemas.Done
 import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.Oppgave
+import no.nav.syfo.syfosmvarsel.log
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 
@@ -13,10 +14,20 @@ class BrukernotifikasjonKafkaProducer(
     private val brukernotifikasjonDoneTopic: String
 ) {
     fun sendOpprettmelding(nokkel: Nokkel, oppgave: Oppgave) {
-        kafkaproducerOpprett.send(ProducerRecord(brukernotifikasjonOpprettTopic, nokkel, oppgave))
+        try {
+            kafkaproducerOpprett.send(ProducerRecord(brukernotifikasjonOpprettTopic, nokkel, oppgave)).get()
+        } catch (e: Exception) {
+            log.error("Noe gikk galt ved sending av oppgave med id {}: ${e.message}", nokkel.getEventId())
+            throw e
+        }
     }
 
     fun sendDonemelding(nokkel: Nokkel, done: Done) {
-        kafkaproducerDone.send(ProducerRecord(brukernotifikasjonDoneTopic, nokkel, done))
+        try {
+            kafkaproducerDone.send(ProducerRecord(brukernotifikasjonDoneTopic, nokkel, done)).get()
+        } catch (e: Exception) {
+            log.error("Noe gikk galt ved ferdigstilling av oppgave med id {}: ${e.message}", nokkel.getEventId())
+            throw e
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/DbQueries.kt
@@ -8,29 +8,36 @@ import java.util.UUID
 import no.nav.syfo.syfosmvarsel.application.db.DatabaseInterface
 import no.nav.syfo.syfosmvarsel.application.db.toList
 
-fun DatabaseInterface.hentBrukernotifikasjon(sykmeldingId: UUID, event: String): BrukernotifikasjonDB? =
+fun DatabaseInterface.brukernotifikasjonFinnesFraFor(sykmeldingId: UUID, event: String): Boolean {
     connection.use { connection ->
-        val brukernotifikasjoner = connection.hentBrukernotifikasjon(sykmeldingId, event)
+        return connection.finnesFraFor(sykmeldingId, event)
+    }
+}
+
+fun DatabaseInterface.hentApenBrukernotifikasjon(sykmeldingId: UUID, event: String): BrukernotifikasjonDB? =
+    connection.use { connection ->
+        if (connection.finnesFraFor(sykmeldingId, event)) {
+            return null
+        }
+        val brukernotifikasjoner = connection.hentApenBrukernotifikasjon(sykmeldingId)
         return brukernotifikasjoner.firstOrNull()
     }
 
 fun DatabaseInterface.registrerBrukernotifikasjon(brukernotifikasjonDB: BrukernotifikasjonDB) {
     connection.use { connection ->
-        if (!connection.finnesFraFor(brukernotifikasjonDB)) {
-            connection.registrerBrukernotifikasjon(brukernotifikasjonDB)
+        connection.registrerBrukernotifikasjon(brukernotifikasjonDB)
         connection.commit()
-        }
     }
 }
 
-private fun Connection.finnesFraFor(brukernotifikasjonDB: BrukernotifikasjonDB): Boolean =
+private fun Connection.finnesFraFor(sykmeldingId: UUID, event: String): Boolean =
     this.prepareStatement(
         """
                 SELECT 1 FROM brukernotifikasjon WHERE sykmelding_id=? AND event=?;
                 """
     ).use {
-        it.setObject(1, brukernotifikasjonDB.sykmeldingId)
-        it.setString(2, brukernotifikasjonDB.event)
+        it.setObject(1, sykmeldingId)
+        it.setString(2, event)
         it.executeQuery().next()
     }
 
@@ -50,16 +57,15 @@ fun Connection.registrerBrukernotifikasjon(brukernotifikasjonDB: Brukernotifikas
     }
 }
 
-private fun Connection.hentBrukernotifikasjon(sykmeldingId: UUID, event: String): List<BrukernotifikasjonDB> =
+private fun Connection.hentApenBrukernotifikasjon(sykmeldingId: UUID): List<BrukernotifikasjonDB> =
     this.prepareStatement(
         """
                  SELECT *
                    FROM brukernotifikasjon
-                  WHERE sykmelding_id = ? AND event != ?
+                  WHERE sykmelding_id = ? AND event = 'APEN'
             """
     ).use {
         it.setObject(1, sykmeldingId)
-        it.setString(2, event)
         it.executeQuery().toList { tilBrukernotifikasjon() }
     }
 

--- a/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/DbQueries.kt
@@ -44,7 +44,7 @@ private fun Connection.finnesFraFor(sykmeldingId: UUID, event: String): Boolean 
 fun Connection.registrerBrukernotifikasjon(brukernotifikasjonDB: BrukernotifikasjonDB) {
     this.prepareStatement(
         """
-                INSERT INTO brukernotifikasjon(sykmelding_id, timestamp, event, grupperingsId, eventId, notifikasjonstatus) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING
+                INSERT INTO brukernotifikasjon(sykmelding_id, timestamp, event, grupperingsId, eventId, notifikasjonstatus) VALUES (?, ?, ?, ?, ?, ?)
                 """
     ).use {
         it.setObject(1, brukernotifikasjonDB.sykmeldingId)

--- a/src/main/kotlin/no/nav/syfo/syfosmvarsel/util/KafkaFactory.kt
+++ b/src/main/kotlin/no/nav/syfo/syfosmvarsel/util/KafkaFactory.kt
@@ -42,8 +42,7 @@ class KafkaFactory private constructor() {
 
         fun getKafkaStatusConsumer(vaultSecrets: VaultSecrets, environment: Environment): KafkaConsumer<String, SykmeldingStatusKafkaMessageDTO> {
             val kafkaBaseConfigForStatus = loadBaseConfig(environment, vaultSecrets).envOverrides()
-            kafkaBaseConfigForStatus["auto.offset.reset"] = "latest"
-            val properties = kafkaBaseConfigForStatus.toConsumerConfig("syfosmvarsel-consumer-2", JacksonKafkaDeserializer::class)
+            val properties = kafkaBaseConfigForStatus.toConsumerConfig("syfosmvarsel-consumer-3", JacksonKafkaDeserializer::class)
             properties.let { it[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1" }
             val kafkaStatusConsumer = KafkaConsumer<String, SykmeldingStatusKafkaMessageDTO>(properties, StringDeserializer(), JacksonKafkaDeserializer(SykmeldingStatusKafkaMessageDTO::class))
             kafkaStatusConsumer.subscribe(listOf(environment.sykmeldingStatusTopic))

--- a/src/test/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/BrukernotifikasjonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/syfosmvarsel/brukernotifikasjon/BrukernotifikasjonServiceSpek.kt
@@ -175,6 +175,23 @@ class BrukernotifikasjonServiceSpek : Spek({
             val brukernotifikasjoner = database.connection.hentBrukernotifikasjonListe(sykmeldingId)
             brukernotifikasjoner.size shouldEqual 0
         }
+
+        it("ferdigstillBrukernotifikasjon oppretter kun done en gang") {
+            database.registrerBrukernotifikasjon(brukernotifikasjonDB)
+
+            brukernotifikasjonService.ferdigstillBrukernotifikasjon(sykmeldingStatusKafkaMessageDTO)
+            brukernotifikasjonService.ferdigstillBrukernotifikasjon(sykmeldingStatusKafkaMessageDTO)
+
+            val brukernotifikasjoner = database.connection.hentBrukernotifikasjonListe(sykmeldingId)
+            brukernotifikasjoner.size shouldEqual 2
+            brukernotifikasjoner[0].sykmeldingId shouldEqual sykmeldingId
+            brukernotifikasjoner[0].timestamp shouldEqual timestampFerdig
+            brukernotifikasjoner[0].event shouldEqual "SENDT"
+            brukernotifikasjoner[0].grupperingsId shouldEqual sykmeldingId
+            brukernotifikasjoner[0].eventId shouldNotBe null
+            brukernotifikasjoner[0].notifikasjonstatus shouldEqual Notifikasjonstatus.FERDIG
+            brukernotifikasjoner[1] shouldEqual brukernotifikasjonDB
+        }
     }
 
     describe("Ende til ende-test oppgave") {


### PR DESCRIPTION
Flere endringer: 
- sørger for at kafkaproducere ikke feiler silently lenger
- skal ikke sende done-meldinger hvis vi allerede har gjort det for en gitt sykmelding (jeg tror egentlig det fungerte før også, men det var i så fall flaks, for det var noe feil i logikken her..)
- leser alle statusendringer på nytt for å få sendt done-melding for sykmelding som ble sendt før den ble mottatt